### PR TITLE
Refactored Exercise#category to be an enum instead of s string.

### DIFF
--- a/src/main/java/com/ssa/ironyard/fitness/dao/AbstractSpringDAO.java
+++ b/src/main/java/com/ssa/ironyard/fitness/dao/AbstractSpringDAO.java
@@ -51,6 +51,7 @@ public abstract class AbstractSpringDAO<T extends DomainObject> implements DAO<T
             insertPreparer(statement, domain);
             return statement;
         }, generatedId) == 1) {
+            @SuppressWarnings("unchecked")
             T copy = (T) domain.clone(); // necessary to maintain 'immutable'
                                          // semantics
             return afterInsert(copy, generatedId.getKey().intValue());
@@ -59,6 +60,7 @@ public abstract class AbstractSpringDAO<T extends DomainObject> implements DAO<T
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public T update(T domain) {
         if (null == domain || null == domain.getId())
             return null;

--- a/src/main/java/com/ssa/ironyard/fitness/dao/ExerciseDAO.java
+++ b/src/main/java/com/ssa/ironyard/fitness/dao/ExerciseDAO.java
@@ -1,7 +1,9 @@
 package com.ssa.ironyard.fitness.dao;
 
 import com.ssa.ironyard.fitness.model.Exercise;
+import java.util.List;
 
-public interface ExerciseDAO extends DAO<Exercise>{
-
+public interface ExerciseDAO extends DAO<Exercise>
+{
+    List<Exercise> readAll();
 }

--- a/src/main/java/com/ssa/ironyard/fitness/dao/ExerciseDAOImpl.java
+++ b/src/main/java/com/ssa/ironyard/fitness/dao/ExerciseDAOImpl.java
@@ -27,6 +27,7 @@ public class ExerciseDAOImpl extends AbstractSpringDAO<Exercise> implements Exer
         }, datasource);
     }
 
+    @Override
     public List<Exercise> readAll() {
         List<Exercise> temp = new ArrayList<>();
         return this.springTemplate.query(((ExerciseORM) this.orm).readAll(), (ResultSet cursor) -> {
@@ -44,11 +45,7 @@ public class ExerciseDAOImpl extends AbstractSpringDAO<Exercise> implements Exer
     @Override
     protected void insertPreparer(PreparedStatement insertStatement, Exercise domainToInsert) throws SQLException {
 
-        insertStatement.setString(1, domainToInsert.getExercise_name());
-        insertStatement.setString(2, domainToInsert.getCategory());
-        insertStatement.setString(3, domainToInsert.getMuscles());
-        insertStatement.setString(4, domainToInsert.getImage());
-        insertStatement.setString(5, domainToInsert.getInstructions());
+        mapDomainToPreparedStatement(insertStatement, domainToInsert, 1);
 
     }
 
@@ -70,14 +67,22 @@ public class ExerciseDAOImpl extends AbstractSpringDAO<Exercise> implements Exer
     @Override
     protected PreparedStatementSetter updatePreparer(Exercise domainToUpdate) {
         return (PreparedStatement ps) -> {
-            ps.setInt(1, domainToUpdate.getId());
-            ps.setString(2, domainToUpdate.getExercise_name());
-            ps.setString(2, domainToUpdate.getCategory());
-            ps.setString(3, domainToUpdate.getMuscles());
-            ps.setString(4, domainToUpdate.getImage());
-            ps.setString(5, domainToUpdate.getInstructions());
+            
+            int lastParameter = mapDomainToPreparedStatement(ps, domainToUpdate, 1);
+            ps.setInt(lastParameter, domainToUpdate.getId());
 
         };
+    }
+    
+    static int mapDomainToPreparedStatement(PreparedStatement preparedStatement, Exercise exercise, 
+                                            int parameterIndex) throws SQLException
+    {
+        preparedStatement.setString(parameterIndex++, exercise.getExercise_name());
+        preparedStatement.setString(parameterIndex++, exercise.getCategory().getData());
+        preparedStatement.setString(parameterIndex++, exercise.getMuscles());
+        preparedStatement.setString(parameterIndex++, exercise.getImage());
+        preparedStatement.setString(parameterIndex++, exercise.getInstructions());
+        return parameterIndex;
     }
 
 }

--- a/src/main/java/com/ssa/ironyard/fitness/dao/ExerciseORM.java
+++ b/src/main/java/com/ssa/ironyard/fitness/dao/ExerciseORM.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.util.StringJoiner;
 
 import com.ssa.ironyard.fitness.model.Exercise;
+import com.ssa.ironyard.fitness.model.Exercise.Category;
 
 public interface ExerciseORM extends ORM<Exercise> {
 
@@ -27,7 +28,7 @@ public interface ExerciseORM extends ORM<Exercise> {
             final String columnPrefix = table() + ".";
             e.setId(results.getInt(columnPrefix + "id"));
             e.setExercise_name(results.getString(columnPrefix + "exercise_name"));
-            e.setCategory(results.getString(columnPrefix + "category"));
+            e.setCategory(Category.getInstance(results.getString(columnPrefix + "category")));
             e.setMuscles(results.getString(columnPrefix + "muscles"));
             e.setImage(results.getString(columnPrefix + "image"));
             e.setInstructions(results.getString(columnPrefix + "instructions"));
@@ -69,8 +70,8 @@ public interface ExerciseORM extends ORM<Exercise> {
     };
 
     default String readAll() {
-        ;
-        return "SELECT * FROM " + table();
+        
+        return "SELECT " + projection() + " FROM " + table();
     }
 
 }

--- a/src/main/java/com/ssa/ironyard/fitness/model/Exercise.java
+++ b/src/main/java/com/ssa/ironyard/fitness/model/Exercise.java
@@ -3,7 +3,7 @@ package com.ssa.ironyard.fitness.model;
 public class Exercise implements DomainObject {
     Integer id;
     String exercise_name;
-    String category;
+    Category cat;
     String muscles;
     String image;
     String instructions;
@@ -32,12 +32,12 @@ public class Exercise implements DomainObject {
         this.exercise_name = exercise_name;
     }
 
-    public String getCategory() {
-        return category;
+    public Category getCategory() {
+        return this.cat;
     }
 
-    public void setCategory(String category) {
-        this.category = category;
+    public void setCategory(Category category) {
+        this.cat = category;
     }
 
     public String getMuscles() {
@@ -101,11 +101,9 @@ public class Exercise implements DomainObject {
         if (getClass() != obj.getClass())
             return false;
         Exercise other = (Exercise) obj;
-        if (category == null) {
-            if (other.category != null)
-                return false;
-        } else if (!category.equals(other.category))
+        if (this.cat != other.cat)
             return false;
+        
         if (exercise_name == null) {
             if (other.exercise_name != null)
                 return false;
@@ -147,4 +145,42 @@ public class Exercise implements DomainObject {
         return null;
     }
 
+    public static enum Category
+    {
+        ARMS("arms", "AR"), CHEST("Chest", "CH"), CARDIO("Cardio", "CA"); //TODO fill in rest to match what is in data-file
+        
+        
+        private final String display, data;
+
+        private Category(String display, String data)
+        {
+            this.display = display;
+            this.data = data;
+        }
+        
+        public static Category getInstance(String data)
+        {
+            data = data.toUpperCase();
+            for (Category category : values())
+            {
+                if (category.data.equals(data))
+                    return category;
+            }
+            return null;
+        }
+
+        public String getData()
+        {
+            return this.data;
+        }
+        
+        @Override
+        public String toString()
+        {
+            return this.display;
+        }
+        
+        
+    };
+            
 }

--- a/src/main/java/com/ssa/ironyard/fitness/services/FitnessExerciseServiceImpl.java
+++ b/src/main/java/com/ssa/ironyard/fitness/services/FitnessExerciseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ssa.ironyard.fitness.services;
 
+import com.ssa.ironyard.fitness.dao.ExerciseDAO;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +14,10 @@ import com.ssa.ironyard.fitness.model.Exercise;
 public class FitnessExerciseServiceImpl
 {
 
-    ExerciseDAOImpl daoExercise;
+    final ExerciseDAO daoExercise;
 
     @Autowired
-    public FitnessExerciseServiceImpl(ExerciseDAOImpl daoExercise)
+    public FitnessExerciseServiceImpl(ExerciseDAO daoExercise)
     {
         this.daoExercise = daoExercise;
     }

--- a/src/main/java/com/ssa/ironyard/fitness/utils/FileLoadingService.java
+++ b/src/main/java/com/ssa/ironyard/fitness/utils/FileLoadingService.java
@@ -18,6 +18,7 @@ import com.ssa.ironyard.fitness.dao.ExerciseDAOImpl;
 import com.ssa.ironyard.fitness.dao.RegimenDAOImpl;
 import com.ssa.ironyard.fitness.dao.WorkoutHistoryDAOImpl;
 import com.ssa.ironyard.fitness.model.Exercise;
+import com.ssa.ironyard.fitness.model.Exercise.Category;
 import com.ssa.ironyard.fitness.services.DataSourceConfiguration;
 
 public class FileLoadingService {
@@ -64,7 +65,7 @@ public class FileLoadingService {
                 String instructions = exerciseList.get(6).replaceAll("( )+", " ");
                 
                 Exercise e = new Exercise();
-                e.setCategory(exerciseList.get(0));
+                e.setCategory(Category.getInstance(exerciseList.get(0)));
                 if(!muscle.get(2).equals("(Articulation)"))
                     e.setMuscles(muscle.get(2).trim());
                 else if(muscle.get(2).equals("(see"))

--- a/src/test/java/com/ssa/ironyard/fitness/controller/FitnessAccountControllerTest.java
+++ b/src/test/java/com/ssa/ironyard/fitness/controller/FitnessAccountControllerTest.java
@@ -12,11 +12,9 @@ import org.junit.Test;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import com.ssa.ironyard.fitness.crypto.BCryptSecurePassword;
 import com.ssa.ironyard.fitness.model.Account;
 import com.ssa.ironyard.fitness.model.Exercise;
 import com.ssa.ironyard.fitness.model.Goal;
-import com.ssa.ironyard.fitness.model.Password;
 import com.ssa.ironyard.fitness.model.WorkoutHistory;
 import com.ssa.ironyard.fitness.services.FitnessAccountServiceImpl;
 import com.ssa.ironyard.fitness.services.FitnessHistoryServiceImpl;

--- a/src/test/java/com/ssa/ironyard/fitness/daoTests/ExerciseTests.java
+++ b/src/test/java/com/ssa/ironyard/fitness/daoTests/ExerciseTests.java
@@ -11,6 +11,7 @@ import com.mysql.cj.jdbc.MysqlDataSource;
 import com.ssa.ironyard.fitness.dao.ExerciseDAOImpl;
 import com.ssa.ironyard.fitness.dao.WorkoutHistoryDAOImpl;
 import com.ssa.ironyard.fitness.model.Exercise;
+import com.ssa.ironyard.fitness.model.Exercise.Category;
 
 public class ExerciseTests {
 
@@ -34,7 +35,7 @@ public class ExerciseTests {
     public void exerciseInsert() {
         Exercise e = new Exercise();
         e.setExercise_name("Push-ups");
-        e.setCategory("Arms");
+        e.setCategory(Category.ARMS);
         e.setImage("http:image.com");
         e.setInstructions("Push up and then push down");
         e.setMuscles("Arms arms arms");
@@ -47,7 +48,7 @@ public class ExerciseTests {
     public void exerciseReadAll() {
         Exercise e = new Exercise();
         e.setExercise_name("Push-ups");
-        e.setCategory("Arms");
+        e.setCategory(Category.ARMS);
         e.setImage("http:image.com");
         e.setInstructions("Push up and then push down");
         e.setMuscles("Arms arms arms");
@@ -55,7 +56,7 @@ public class ExerciseTests {
 
         Exercise e2 = new Exercise();
         e2.setExercise_name("Push-ups");
-        e2.setCategory("Arms");
+        e2.setCategory(Category.ARMS);
         e2.setImage("http:image.com");
         e2.setInstructions("Push up and then push down");
         e2.setMuscles("Arms arms arms");

--- a/src/test/java/com/ssa/ironyard/fitness/daoTests/RegimenTests.java
+++ b/src/test/java/com/ssa/ironyard/fitness/daoTests/RegimenTests.java
@@ -16,6 +16,7 @@ import com.ssa.ironyard.fitness.dao.GoalDAOImpl;
 import com.ssa.ironyard.fitness.dao.RegimenDAOImpl;
 import com.ssa.ironyard.fitness.model.Account;
 import com.ssa.ironyard.fitness.model.Exercise;
+import com.ssa.ironyard.fitness.model.Exercise.Category;
 import com.ssa.ironyard.fitness.model.Goal;
 import com.ssa.ironyard.fitness.model.Password;
 import com.ssa.ironyard.fitness.model.Regimen;
@@ -69,7 +70,7 @@ public class RegimenTests {
 
         Exercise e = new Exercise();
         e.setExercise_name("Push-ups");
-        e.setCategory("Arms");
+        e.setCategory(Category.ARMS);
         e.setImage("http:image.com");
         e.setInstructions("Push up and then push down");
         e.setMuscles("Arms arms arms");
@@ -115,7 +116,7 @@ public class RegimenTests {
 
         Exercise e = new Exercise();
         e.setExercise_name("Push-ups");
-        e.setCategory("Arms");
+        e.setCategory(Category.ARMS);
         e.setImage("http:image.com");
         e.setInstructions("Push up and then push down");
         e.setMuscles("Arms arms arms");

--- a/src/test/java/com/ssa/ironyard/fitness/daoTests/WorkoutHistoryTests.java
+++ b/src/test/java/com/ssa/ironyard/fitness/daoTests/WorkoutHistoryTests.java
@@ -19,6 +19,7 @@ import com.ssa.ironyard.fitness.dao.WeeklyScoreDAOImpl;
 import com.ssa.ironyard.fitness.dao.WorkoutHistoryDAOImpl;
 import com.ssa.ironyard.fitness.model.Account;
 import com.ssa.ironyard.fitness.model.Exercise;
+import com.ssa.ironyard.fitness.model.Exercise.Category;
 import com.ssa.ironyard.fitness.model.Goal;
 import com.ssa.ironyard.fitness.model.Password;
 import com.ssa.ironyard.fitness.model.WorkoutHistory;
@@ -73,7 +74,7 @@ public class WorkoutHistoryTests {
 
         Exercise e = new Exercise();
         e.setExercise_name("Push-ups");
-        e.setCategory("Arms");
+        e.setCategory(Category.ARMS);
         e.setImage("http:image.com");
         e.setInstructions("Push up and then push down");
         e.setMuscles("Arms arms arms");
@@ -118,7 +119,7 @@ public class WorkoutHistoryTests {
 
         Exercise e = new Exercise();
         e.setExercise_name("Push-ups");
-        e.setCategory("Arms");
+        e.setCategory(Category.ARMS);
         e.setImage("http:image.com");
         e.setInstructions("Push up and then push down");
         e.setMuscles("Arms arms arms");


### PR DESCRIPTION
Cleaned up the DAOs as well as accommodating the above
Added #readAll to the ExerciseDAO interface (it was only defined on the
impl)
And innumerous other beautiful things


You'll need to flesh out the Category enums and have the #data property use whatever is in your FileLoadingService

Note: this will change the JSON that is sent as a response, viz.
<code>
{

category: {
    data: ' xxxx',
    display: 'zzzz'
}

}

